### PR TITLE
Feature/add new syntax to comparison matchers

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,8 +109,13 @@ expect { ... }.to perform_slower_than { ... }
 
 And if you want to compare how much faster or slower your code compared to other do:
 ```ruby
-expect { ... }.to perform_faster_than { ... }.in(5).times
-expect { ... }.to perform_slower_than { ... }.in(5).times
+expect { ... }.to perform_faster_than { ... }.at_least(5).times
+expect { ... }.to perform_faster_than { ... }.at_most(5).times
+expect { ... }.to perform_faster_than { ... }.exactly(5).times
+
+expect { ... }.to perform_slower_than { ... }.at_least(5).times
+expect { ... }.to perform_slower_than { ... }.at_most(5).times
+expect { ... }.to perform_slower_than { ... }.exactly(5).times
 ```
 
 The `times` part is also optional.

--- a/lib/rspec/benchmark/comparison_matcher.rb
+++ b/lib/rspec/benchmark/comparison_matcher.rb
@@ -140,7 +140,7 @@ module RSpec
         #   perform_faster_than { ... }.exactly(@amount).times # => false
         # @api private
         def exactly_comparison
-          (amount - 0.3 .. amount + 0.3).include? actual
+          (amount - 0.33 .. amount + 0.33).include? actual
         end
 
         # @return [Boolean]

--- a/lib/rspec/benchmark/comparison_matcher.rb
+++ b/lib/rspec/benchmark/comparison_matcher.rb
@@ -140,7 +140,7 @@ module RSpec
         #   perform_faster_than { ... }.exactly(@amount).times # => false
         # @api private
         def exactly_comparison
-          (amount - 0.25 .. amount + 0.25).include? actual
+          (amount - 0.3 .. amount + 0.3).include? actual
         end
 
         # @return [Boolean]

--- a/lib/rspec/benchmark/comparison_matcher.rb
+++ b/lib/rspec/benchmark/comparison_matcher.rb
@@ -11,7 +11,8 @@ module RSpec
                     :amount,
                     :iterations,
                     :sample_iterations,
-                    :comparison_type
+                    :comparison_type,
+                    :threshold_type
 
         def initialize(sample, comparison_type, options = {})
           check_comparison(comparison_type)
@@ -37,15 +38,33 @@ module RSpec
           @sample_iterations = ips_for(sample)
           @iterations = ips_for(block)
 
-          if comparison_type == :faster
-            iterations / amount > sample_iterations
+          case threshold_type
+          when :at_least
+            default_comparison
+          when :at_most
+            at_most_comparison
+          when :exactly
+            exactly_comparison
           else
-            iterations / amount < sample_iterations
+            default_comparison
           end
         end
 
-        def in(amount)
+        def at_least(amount)
           @amount = amount
+          @threshold_type = :at_least
+          self
+        end
+
+        def at_most(amount)
+          @amount = amount
+          @threshold_type = :at_most
+          self
+        end
+
+        def exactly(amount)
+          @amount = amount
+          @threshold_type = :exactly
           self
         end
 
@@ -65,7 +84,8 @@ module RSpec
           if amount == 1
             "perform #{comparison_type} than passed block"
           else
-            "perform #{comparison_type} than passed block in #{@amount} times"
+            "perform #{comparison_type} than passed block " \
+            "#{threshold_type} in #{amount} times"
           end
         end
 
@@ -80,6 +100,76 @@ module RSpec
         end
 
         private
+
+        # @return [Boolean]
+        # @example
+        #   @actual = 40
+        #   @amount = 41
+        #   perform_faster_than { ... }.at_most(@amount).times # => true
+        #
+        #   @actual = 40
+        #   @amount = 41
+        #   perform_faster_than { ... }.at_most(@amount).times # => false
+        #
+        #   @actual = 1/40
+        #   @amount = 41
+        #   perform_slower_than { ... }.at_most(@amount).times # => true
+        #
+        #   @actual = 1/40
+        #   @amount = 41
+        #   perform_slower_than { ... }.at_most(@amount).times # => false
+        # @api private
+        def at_most_comparison
+          if comparison_type == :faster
+            1 < actual && actual < amount
+          else
+            actual < 1 && actual > 1 / amount.to_f
+          end
+        end
+
+        # @return [Boolean]
+        # @example
+        #   @actual = 40.1
+        #   @amount = 40
+        #   perform_faster_than { ... }.exactly(@amount).times # => true
+        #
+        #   @actual = 39.9
+        #   @amount = 40
+        #   perform_faster_than { ... }.exactly(@amount).times # => true
+        #
+        #   @actual = 40.2
+        #   @amount = 40
+        #   perform_faster_than { ... }.exactly(@amount).times # => false
+        # @api private
+        def exactly_comparison
+          (amount - 0.1 .. amount + 0.1).include? actual
+        end
+
+        # @return [Boolean]
+        # @example
+        #   @actual = 41
+        #   @amount = 40
+        #   perform_faster_than { ... } # => true
+        #
+        #   @actual = 41
+        #   @amount = 40
+        #   perform_faster_than { ... }.at_least(@amount).times # => true
+        #
+        #   @actual = 1/40
+        #   @amount = 41
+        #   perform_slower_than { ... }.at_least(@amount).times # => false
+        #
+        #   @actual = 1/41
+        #   @amount = 40
+        #   perform_slower_than { ... }.at_least(@amount).times # => true
+        # @api private
+        def default_comparison
+          if comparison_type == :faster
+            actual / amount > 1
+          else
+            actual / amount < 1 / amount.to_f
+          end
+        end
 
         def check_comparison(type)
           [:slower, :faster].include?(type) ||

--- a/lib/rspec/benchmark/comparison_matcher.rb
+++ b/lib/rspec/benchmark/comparison_matcher.rb
@@ -39,8 +39,6 @@ module RSpec
           @iterations = ips_for(block)
 
           case threshold_type
-          when :at_least
-            default_comparison
           when :at_most
             at_most_comparison
           when :exactly
@@ -133,16 +131,16 @@ module RSpec
         #   @amount = 40
         #   perform_faster_than { ... }.exactly(@amount).times # => true
         #
-        #   @actual = 39.9
+        #   @actual = 45
         #   @amount = 40
         #   perform_faster_than { ... }.exactly(@amount).times # => true
         #
-        #   @actual = 40.2
+        #   @actual = 55
         #   @amount = 40
         #   perform_faster_than { ... }.exactly(@amount).times # => false
         # @api private
         def exactly_comparison
-          (amount - 0.1 .. amount + 0.1).include? actual
+          (amount - 0.25 .. amount + 0.25).include? actual
         end
 
         # @return [Boolean]

--- a/spec/unit/comparison_matcher_spec.rb
+++ b/spec/unit/comparison_matcher_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe RSpec::Benchmark::ComparisonMatcher::Matcher do
       it "passes if the block performs faster than sample" do
         expect {
           1 << 1
-        }.to perform_faster_than { 'x' * 10 * 1024 }.at_most(100).times
+        }.to perform_faster_than { 'x' * 10 * 1024 }.at_most(125).times
       end
 
       it "fails if the block performs faster than sample more than in 20 times" do
@@ -175,7 +175,7 @@ RSpec.describe RSpec::Benchmark::ComparisonMatcher::Matcher do
       it "passes if the block performs faster than sample" do
         expect {
           'x' * 10 * 1024
-        }.to perform_slower_than { 1 << 1 }.at_most(100).times
+        }.to perform_slower_than { 1 << 1 }.at_most(125).times
       end
 
       it "fails if the block performs slower than sample more than in 20 times" do

--- a/spec/unit/comparison_matcher_spec.rb
+++ b/spec/unit/comparison_matcher_spec.rb
@@ -25,19 +25,19 @@ RSpec.describe RSpec::Benchmark::ComparisonMatcher::Matcher do
       end
     end
 
-    context "expect { ... }.to perform_faster_than(...).in(...).times" do
+    context "expect { ... }.to perform_faster_than(...).at_least(...).times" do
       it "passes if the block performs faster than sample" do
         expect {
           1 << 1
-        }.to perform_faster_than { 'x' * 10 * 1024 }.in(2).times
+        }.to perform_faster_than { 'x' * 10 * 1024 }.at_least(2).times
       end
 
       it "fails if the block performs faster than sample" do
         expect {
           expect {
             'x' * 10 * 1024
-          }.to perform_faster_than { 1 << 1 }.in(5).times
-        }.to raise_error(/expected block to perform faster than passed block in \d+ times, but performed slower in \d+.\d+ times/)
+          }.to perform_faster_than { 1 << 1 }.at_least(5).times
+        }.to raise_error(/expected block to perform faster than passed block at_least in \d+ times, but performed slower in \d+.\d+ times/)
       end
     end
 
@@ -57,19 +57,43 @@ RSpec.describe RSpec::Benchmark::ComparisonMatcher::Matcher do
       end
     end
 
-    context "expect { ... }.not_to perform_faster_than(...).in(...).times" do
+    context "expect { ... }.not_to perform_faster_than(...).at_least(...).times" do
       it "passes if the block performs slower than sample" do
         expect {
           'x' * 10 * 1024
-        }.not_to perform_faster_than { 1 << 1 }.in(20).times
+        }.not_to perform_faster_than { 1 << 1 }.at_least(20).times
       end
 
       it "fails if the block performs faster than sample" do
         expect {
           expect {
             1 << 1
-          }.not_to perform_faster_than { 'x' * 10 * 1024 }.in(2).times
-        }.to raise_error(/expected block not to perform faster than passed block in \d+ times, but performed faster in \d+.\d+ times/)
+          }.not_to perform_faster_than { 'x' * 10 * 1024 }.at_least(2).times
+        }.to raise_error(/expected block not to perform faster than passed block at_least in \d+ times, but performed faster in \d+.\d+ times/)
+      end
+    end
+
+    context "expect { ... }.to perform_faster_than.{ ... }.exactly(...).times" do
+      it "passes if the block performs faster than sample" do
+        expect {
+          1 << 1
+        }.to perform_faster_than { 1 << 1 }.exactly(1).times
+      end
+    end
+
+    context "expect { ... }.to perform_faster_than.{ ... }.at_most(...).times" do
+      it "passes if the block performs faster than sample" do
+        expect {
+          1 << 1
+        }.to perform_faster_than { 'x' * 10 * 1024 }.at_most(100).times
+      end
+
+      it "fails if the block performs faster than sample more than in 20 times" do
+        expect {
+          expect {
+            1 << 1
+          }.to perform_faster_than { 'x' * 10 * 1024 }.at_most(10).times
+        }.to raise_error(/expected block to perform faster than passed block at_most in \d+ times, but performed faster in \d+.\d+ times/)
       end
     end
   end
@@ -91,19 +115,19 @@ RSpec.describe RSpec::Benchmark::ComparisonMatcher::Matcher do
       end
     end
 
-    context "expect { ... }.not_to perform_slower_than(...).in(...).times" do
+    context "expect { ... }.not_to perform_slower_than(...).at_least(...).times" do
       it "passes if the block performs faster than sample" do
         expect {
           1 << 1
-        }.not_to perform_slower_than { 'x' * 10 * 1024 }.in(2).times
+        }.not_to perform_slower_than { 'x' * 10 * 1024 }.at_least(2).times
       end
 
       it "fails if the block performs slower than sample" do
         expect {
           expect {
             'x' * 10 * 1024
-          }.not_to perform_slower_than { 1 << 1 }.in(5).times
-        }.to raise_error(/expected block not to perform slower than passed block in \d+ times, but performed slower in \d+.\d+ times/)
+          }.not_to perform_slower_than { 1 << 1 }.at_least(5).times
+        }.to raise_error(/expected block not to perform slower than passed block at_least in \d+ times, but performed slower in \d+.\d+ times/)
       end
     end
 
@@ -123,19 +147,43 @@ RSpec.describe RSpec::Benchmark::ComparisonMatcher::Matcher do
       end
     end
 
-    context "expect { ... }.not_to perform_slower_than(...).in(...).times" do
+    context "expect { ... }.not_to perform_slower_than(...).at_least(...).times" do
       it "passes if the block does performs slower than sample" do
         expect {
           'x' * 10 * 1024
-        }.to perform_slower_than { 1 << 1 }.in(20).times
+        }.to perform_slower_than { 1 << 1 }.at_least(20).times
       end
 
       it "fails if the block does performs faster than sample" do
         expect {
           expect {
             1 << 1
-          }.to perform_slower_than { 'x' * 10 * 1024 }.in(2).times
-        }.to raise_error(/expected block to perform slower than passed block in \d+ times, but performed faster in \d+.\d+ times/)
+          }.to perform_slower_than { 'x' * 10 * 1024 }.at_least(2).times
+        }.to raise_error(/expected block to perform slower than passed block at_least in \d+ times, but performed faster in \d+.\d+ times/)
+      end
+    end
+
+    context "expect { ... }.to perform_slower_than.{ ... }.exactly(...).times" do
+      it "passes if the block performs slower than sample" do
+        expect {
+          1 << 1
+        }.to perform_slower_than { 1 << 1 }.exactly(1).times
+      end
+    end
+
+    context "expect { ... }.to perform_slower_than.{ ... }.at_most(...).times" do
+      it "passes if the block performs faster than sample" do
+        expect {
+          'x' * 10 * 1024
+        }.to perform_slower_than { 1 << 1 }.at_most(100).times
+      end
+
+      it "fails if the block performs slower than sample more than in 20 times" do
+        expect {
+          expect {
+            'x' * 10 * 1024
+          }.to perform_slower_than { 1 << 1 }.at_most(10).times
+        }.to raise_error(/expected block to perform slower than passed block at_most in \d+ times, but performed slower in \d+.\d+ times/)
       end
     end
   end

--- a/spec/unit/comparison_matcher_spec.rb
+++ b/spec/unit/comparison_matcher_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe RSpec::Benchmark::ComparisonMatcher::Matcher do
         expect {
           expect {
             1 << 1
-          }.to perform_faster_than { 'x' * 10 * 1024 }.at_most(10).times
+          }.to perform_faster_than { 'x' * 10 * 1024 }.at_most(2).times
         }.to raise_error(/expected block to perform faster than passed block at_most in \d+ times, but performed faster in \d+.\d+ times/)
       end
     end
@@ -182,7 +182,7 @@ RSpec.describe RSpec::Benchmark::ComparisonMatcher::Matcher do
         expect {
           expect {
             'x' * 10 * 1024
-          }.to perform_slower_than { 1 << 1 }.at_most(10).times
+          }.to perform_slower_than { 1 << 1 }.at_most(2).times
         }.to raise_error(/expected block to perform slower than passed block at_most in \d+ times, but performed slower in \d+.\d+ times/)
       end
     end


### PR DESCRIPTION
I agree with your opinion about using more familiar syntax. Instead of `in(5).times`, i added:
`at_least(5).times` - for perform_faster_than return true, if our code perform faster by more than 5 times in comparison with the sample.
And return true for perform_slower_than if slower more than 5 times.

`at_most(5).times` - for perform_faster_than return true, if our code perform faster in less than 5 times in comparison with the sample.
And return for perform_slower_than if slower less than 5 times.

`exactly(5).times` - true if our code is executed for about the same time( +- 33% ) as the sample.

My English is not good, so i leave comments above all these methods with examples.