### PR TITLE
Add explanation of `perform_allocation` behavior to README #14

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,7 +269,9 @@ expect { |n, i|
 
 The `perform_allocation` matcher checks how much memory or objects have been allocated during a piece of Ruby code execution.
 
-By default the matcher verify the number of object allocations. You can also check for memory allocation using the `bytes` matcher.
+By default the matcher verifies the number of object allocations. The specified number serves as the _upper limit_ of allocations, so your tests won't become brittle as different Ruby versions change internally how many objects are allocated for some operations.
+
+Note that you can also check for memory allocation using the `bytes` matcher.
 
 To check number of objects allocated do:
 


### PR DESCRIPTION
### Describe the change
Improve docs of `perform_allocation`.

### Why are we doing this?
It was a bit unclear that the specified number of objects is actually the upper limit.

### Requirements
Put an X between brackets on each line if you have done the item:
[X] Tests written & passing locally?
[X] Code style checked?
[X] Rebased with `master` branch?
[X] Documentation updated?
