### PR TITLE
Allow chained comparisons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change log
 
+## [v0.7.0]
+
+### Added
+* Change ComparisonMatcher to allow using `at_least` and `at_most` together
+
 ## [v0.6.0] - 2020-03-09
 
 ### Added

--- a/spec/unit/comparison_matcher_spec.rb
+++ b/spec/unit/comparison_matcher_spec.rb
@@ -94,6 +94,28 @@ RSpec.describe RSpec::Benchmark::ComparisonMatcher::Matcher do
         }.to raise_error(/expected given block to perform faster than comparison block by at_most \d+ times, but performed faster by \d+.\d+ times/)
       end
     end
+
+    context 'with both at_least and at_most count' do
+      it "passes if the block performance falls in to the range" do
+        expect { 1 << 1 }.to perform_faster_than { 'x' * 10 * 1024 }.at_least(2).at_most(125)
+      end
+
+      it "fails if the block performance ratio is higher then indicated by at_least" do
+        expect {
+          expect { 1 << 1 }
+            .to perform_faster_than { 'x' * 10 * 1024 }
+            .at_least(2).at_most(15).times
+        }.to raise_error(/expected given block to perform faster than comparison block by at_least \d+ times and by at_most \d+ times, but performed faster by \d+.\d+ times/)
+      end
+
+      it "fails if the block performance ratio is lower then indicated by at_most" do
+        expect {
+          expect {
+            1 << 1
+          }.to perform_faster_than { 'x' * 10 * 1024 }.at_least(200).at_most(300).times
+        }.to raise_error(/expected given block to perform faster than comparison block by at_least \d+ times and by at_most \d+ times, but performed faster by \d+.\d+ times/)
+      end
+    end
   end
 
   context "expect { ... }.not_to perform_faster_than(...)" do

--- a/spec/unit/perform_under_spec.rb
+++ b/spec/unit/perform_under_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe 'RSpec::Benchmark::TimingMatcher', '#perform_under' do
     }.to raise_error(/Repeat value: 0 needs to be greater than 0/)
   end
 
-  context "expect { ... }.to perfom_under(...).sample" do
+  context "expect { ... }.to perform_under(...).sample" do
     it "passes if the block performs under threshold" do
       expect {
         'x' * 1024 * 10
@@ -46,7 +46,7 @@ RSpec.describe 'RSpec::Benchmark::TimingMatcher', '#perform_under' do
       }.to_not perform_under(0.001).sample(2)
     end
 
-    it "fails if the block perfoms under threshold" do
+    it "fails if the block performs under threshold" do
       expect {
         expect {
           'x' * 1024 * 1024 * 10


### PR DESCRIPTION
### Describe the change

This PR allows setting `at_most(x).at_least(x)` without overriding previously defined expectations.

before the change:

```ruby
expect { 2.times.map(&:to_s) }
  .to be_faster_then { 20.times.map(&:to_s) } # ratio is 10.0
  .at_least(99).times
  .at_most(100).times # PASSES because we check only `at_most` value
```

after the change
```ruby
expect { 2.times.map(&:to_s) }
  .to be_faster_then { 20.times.map(&:to_s) } # ratio is 10.0
  .at_least(99).times
  .at_most(100).times # FAILS because we check `at_least` and  `at_most` values
```

### Why are we doing this?

When testing performance with a comparison matcher it's almost impossible to set an `exact` value - each machine will perform a bit differently. But we can set a range where we expect the comparison to fall. Sadly it's hard to do so in an intuitive way as it's not possible to set minimum and maximum count for a single case. Having the possibility to set min and max times count would prevent from false-positives and allow us to better notice changes in performance,

### Benefits

* More intuitive expressions;
* Lower risk of false-positives;

### Drawbacks

Possible drawbacks applying this change: :shrug: 

### Requirements
<!--- Put an X between brackets on each line if you have done the item: -->
- [x] Tests written & passing locally?
- [ ] Code style checked?
- [x] Rebased with `master` branch?
- [ ] Documentation updated?
- [x] Changelog updated?
