### PR TITLE
Add Ruby 3.2 to CI.  Upgrade checkout action. Quote 3.0.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,9 @@ jobs:
           - 2.4
           - 2.5
           - 2.6
-          - 3.0
+          - "3.0"
           - 3.1
+          - 3.2
           - ruby-head
         allow_failure: [true]
         include:
@@ -54,7 +55,7 @@ jobs:
       COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
     continue-on-error: ${{ matrix.allow_failure }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
### Describe the change

- Adds Ruby 3.2 to the CI matrix.
- Quotes 3.0 to avoid truncation
- Updates the checkout action 

### Why are we doing this?

Ruby 3.2 was released in December 2022.  It should be covered in CI.
Quoting the 3.0 avoids truncation.  Without quotes it loads the latest Ruby 3.
Updating the checkout action gets rid of the Node v12 deprecation warnings on the action.

### Benefits

This is a CI change.

### Drawbacks

None

### Requirements
<!--- Put an X between brackets on each line if you have done the item: -->
- [X] Rebased with `master` branch?
